### PR TITLE
Configure OIDC properties to disable authentication. Fixes #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ By default, the order of the combinations is random. In order to disable this co
 mvn clean test -Dts.random-sort-extensions=false
 ```
 
+## How to write custom properties by extension
+
+By convention, the test suite will try to lookup to a property using the name of the extension. For example, if the quarkus extension is called "quarkus-oidc", then the framework will try to load the custom properties at `src/test/resources/oidc.properties` and append the content into the combination application properties file.
+
 # How to contribute
 
 The build instructions are available in the [contribution guide](CONTRIBUTING.md).

--- a/src/main/java/quarkus/extensions/combinator/utils/FileUtils.java
+++ b/src/main/java/quarkus/extensions/combinator/utils/FileUtils.java
@@ -2,8 +2,13 @@ package quarkus.extensions.combinator.utils;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.io.IOUtils;
 
 public final class FileUtils {
 
@@ -35,7 +40,16 @@ public final class FileUtils {
         }
     }
 
-    public static void writeLine(File file, String line) {
+    public static void appendInputStreamIntoFile(InputStream is, File file) {
+        try {
+            List<String> lines = IOUtils.readLines(is, StandardCharsets.UTF_8);
+            org.apache.commons.io.FileUtils.writeLines(file, lines, APPEND);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void appendLineIntoFile(String line, File file) {
         try {
             org.apache.commons.io.FileUtils.writeLines(file, Arrays.asList(line), APPEND);
         } catch (IOException e) {

--- a/src/test/java/quarkus/extensions/combinator/extensions/RecordFailedScenariosTestQuarkusCombinationExtension.java
+++ b/src/test/java/quarkus/extensions/combinator/extensions/RecordFailedScenariosTestQuarkusCombinationExtension.java
@@ -19,7 +19,7 @@ public class RecordFailedScenariosTestQuarkusCombinationExtension implements Tes
 
     @Override
     public void testFailed(ExtensionContext context, Throwable cause) {
-        FileUtils.writeLine(new File(FAILED_FILE), context.getDisplayName());
+        FileUtils.appendLineIntoFile(context.getDisplayName(), new File(FAILED_FILE));
     }
 
 }

--- a/src/test/resources/oidc.properties
+++ b/src/test/resources/oidc.properties
@@ -1,0 +1,5 @@
+quarkus.oidc.tenant-enabled=false
+
+# HTTP Security Configuration
+quarkus.http.auth.permission.authenticated.paths=/*
+quarkus.http.auth.permission.authenticated.policy=permit


### PR DESCRIPTION
Refactor solution to allow a custom properties by extension. 
In this PR, we're configuring the OIDC projects to disable authentication and therefore making the module build.