### PR TITLE
Exclude oidc and smallrye-jwt combination

### DIFF
--- a/src/main/java/quarkus/extensions/combinator/Configuration.java
+++ b/src/main/java/quarkus/extensions/combinator/Configuration.java
@@ -1,8 +1,9 @@
 package quarkus.extensions.combinator;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public enum Configuration {
     ONLY_SUPPORTED_EXTENSIONS("ts.only-supported-extensions", "true"),
@@ -33,7 +34,7 @@ public enum Configuration {
             return Collections.emptyList();
         }
 
-        return Arrays.asList(get().split(","));
+        return Stream.of(get().split(",")).map(String::trim).collect(Collectors.toList());
     }
 
     public Integer getAsInteger() {

--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -1,0 +1,3 @@
+# Multiple mechanisms present that use the same credential transport HttpCredentialTransport. 
+# Mechanisms are io.quarkus.smallrye.jwt.runtime.auth.JWTAuthMechanism and io.quarkus.oidc.runtime.OidcAuthenticationMechanism
+smallrye-jwt,oidc=true


### PR DESCRIPTION
The `oidc` and `smallrye-jwt` combination fails with:

```
ERROR [io.qua.ver.htt.run.QuarkusErrorHandler] (vert.x-eventloop-thread-6) HTTP Request to /hello-resteasy failed, error id: 3d7a1c40-f4ac-4e70-b84b-1dacb2ed69c7-1: java.lang.RuntimeException: Multiple mechanisms present that use the same credential transport HttpCredentialTransport{transportType=AUTHORIZATION, typeTarget='bearer'}. Mechanisms are io.quarkus.smallrye.jwt.runtime.auth.JWTAuthMechanism@4d9c78 and io.quarkus.oidc.runtime.OidcAuthenticationMechanism@559c37a4
```

Therefore, these extensions are incompatible with each other and we should exclude them.