### PR TITLE
Add new exclusions related to new reactive extensions

### DIFF
--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -10,12 +10,19 @@ resteasy,resteasy-jackson=skip-all
 resteasy,resteasy-jsonb=skip-all
 resteasy,resteasy-jaxb=skip-all
 resteasy,resteasy-multipart=skip-all
+rest-client-reactive-jackson,resteasy=skip-all
+resteasy-jackson,resteasy-reactive-jackson=skip-all
+rest-client-reactive-jackson,resteasy-multipart=skip-all
+rest-client-reactive,resteasy-jackson=skip-all
+resteasy,resteasy-reactive-jackson=skip-all
+rest-client-reactive-jackson,undertow=skip-all
 # Multiple producers of item class io.quarkus.deployment.metrics.MetricsCapabilityBuildItem
 # (io.quarkus.micrometer.deployment.MicrometerProcessor and io.quarkus.smallrye.metrics.deployment.SmallRyeMetricsProcessor)
 smallrye-metrics,micrometer=skip-all
 micrometer-registry-prometheus,smallrye-metrics=skip-all
 # Extensions that use testscontainers are currently not supported by Windows
 reactive-pg-client=skip-only-tests-on-windows
+reactive-mysql-client=skip-only-tests-on-windows
 jdbc-mysql=skip-only-tests-on-windows
 jdbc-postgresql=skip-only-tests-on-windows
 jdbc-mssql=skip-only-tests-on-windows


### PR DESCRIPTION
These incompatibilities are making the daily build to fail as reactive and classic are not compatible with each other.