### PR TITLE
CI fixes, Quarkus update

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -7,6 +7,8 @@ jobs:
   linux-build-released-jvm:
     name: Linux - JVM build - released Quarkus
     runs-on: ubuntu-latest
+    env:
+      TESTCONTAINERS_RYUK_DISABLED: true
     strategy:
       matrix:
         java: [ 11 ]
@@ -40,6 +42,8 @@ jobs:
     needs: [ linux-build-released-jvm ]
     if: false # always skip job as it's failing due to memory requirements
     runs-on: ubuntu-latest
+    env:
+      TESTCONTAINERS_RYUK_DISABLED: true
     strategy:
       matrix:
         java: [ 11 ]
@@ -72,6 +76,8 @@ jobs:
     name: Linux - Native build - released Quarkus
     needs: [ linux-build-released-dev ]
     runs-on: ubuntu-latest
+    env:
+      TESTCONTAINERS_RYUK_DISABLED: true
     strategy:
       matrix:
         java: [ 11 ]
@@ -103,6 +109,8 @@ jobs:
   windows-build-released-jvm:
     name: Windows - JVM build - released Quarkus
     runs-on: windows-latest
+    env:
+      TESTCONTAINERS_RYUK_DISABLED: true
     strategy:
       matrix:
         java: [ 11 ]
@@ -138,6 +146,8 @@ jobs:
     needs: [ windows-build-released-jvm ]
     if: false # always skip job as it's failing due to memory requirements
     runs-on: windows-latest
+    env:
+      TESTCONTAINERS_RYUK_DISABLED: true
     strategy:
       matrix:
         java: [ 11 ]
@@ -172,6 +182,8 @@ jobs:
     name: Windows - Native build - released Quarkus
     needs: [ windows-build-released-dev ]
     runs-on: windows-latest
+    env:
+      TESTCONTAINERS_RYUK_DISABLED: true
     strategy:
       matrix:
         java: [ 11 ]

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>2.5.2.Final</quarkus.version>
+        <quarkus.version>2.5.4.Final</quarkus.version>
         <quarkus.ide-config.version>2.6.0.Final</quarkus.ide-config.version>
         <awaitility.version>4.1.1</awaitility.version>
         <rest-assured.version>4.4.0</rest-assured.version>

--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -103,6 +103,7 @@ smallrye-reactive-messaging-kafka=skip-only-tests-on-windows
 smallrye-reactive-messaging-amqp=skip-only-tests-on-windows
 kafka-client=skip-only-tests-on-windows
 oidc=skip-only-tests-on-windows
+infinispan-client=skip-only-tests-on-windows
 # It needs the hibernate dependencies, so skipping it when it's the only dependency:
 camel-quarkus-jpa=skip-all
 debezium-quarkus-outbox=skip-all

--- a/src/main/resources/reactive-mysql-client.properties
+++ b/src/main/resources/reactive-mysql-client.properties
@@ -1,0 +1,1 @@
+quarkus.datasource.jdbc=false


### PR DESCRIPTION
CI fixes, Quarkus update

* dd19cdf - Disable Ryuk to stabilize CI runs (48 seconds ago) <Rostislav Svoboda>
* a50f6c5 - reactive-mysql-client.properties to disable jdbc check (4 minutes ago) <Rostislav Svoboda>
* 21260aa - Ignore infinispan-client on Windows (6 minutes ago) <Rostislav Svoboda>
* ad82fa3 - Quarkus 2.5.4.Final (6 minutes ago) <Rostislav Svoboda>