### PR TITLE
Disable Quarkus Registry Client

### DIFF
--- a/src/main/java/quarkus/extensions/combinator/maven/MavenCommand.java
+++ b/src/main/java/quarkus/extensions/combinator/maven/MavenCommand.java
@@ -23,6 +23,7 @@ public abstract class MavenCommand {
     private static final String QUARKUS_PLATFORM_ARTIFACT_ID = "quarkus.platform.artifact-id";
     private static final List<String> PROPERTIES_TO_PROPAGATE = Arrays.asList(MAVEN_REPO_LOCAL, QUARKUS_PLUGIN_VERSION,
             QUARKUS_PLATFORM_VERSION, QUARKUS_PLATFORM_GROUP_ID, QUARKUS_PLATFORM_ARTIFACT_ID);
+    private static final String QUARKUS_REGISTRY_CLIENT = "quarkusRegistryClient";
 
     private final File workingDirectory;
 
@@ -52,6 +53,10 @@ public abstract class MavenCommand {
 
     protected String withProperty(String property, String value) {
         return String.format("-D%s=%s", property, value);
+    }
+
+    protected String withoutQuarkusRegistryClient() {
+        return withProperty(QUARKUS_REGISTRY_CLIENT, "false");
     }
 
     private CommandBuilder configureMavenCommand(String[] params) {

--- a/src/main/java/quarkus/extensions/combinator/maven/MavenGenerator.java
+++ b/src/main/java/quarkus/extensions/combinator/maven/MavenGenerator.java
@@ -48,7 +48,7 @@ public class MavenGenerator extends MavenCommand {
         FileUtils.deleteDirectory(projectAsWorkingDirectory());
 
         runMavenCommandAndWait(withQuarkusPluginCreate(), withProjectGroupId(), withProjectArtifactId(), withProjectVersion(),
-                withPlatformGroupId(), withPlatformArtifactId(), withExtensions());
+                withPlatformGroupId(), withPlatformArtifactId(), withExtensions(), withoutQuarkusRegistryClient());
         updateApplicationProperties();
         dropEntityAnnotations();
         copyResources();

--- a/src/main/java/quarkus/extensions/combinator/maven/MavenGetQuarkusExtensions.java
+++ b/src/main/java/quarkus/extensions/combinator/maven/MavenGetQuarkusExtensions.java
@@ -14,7 +14,7 @@ public class MavenGetQuarkusExtensions extends MavenCommand {
         extensions.clear();
         String quarkusMavenPlugin = getQuarkusMavenPlugin();
         runMavenCommandAndWait("-f", "target/test-classes/list-extensions.pom.xml", quarkusMavenPlugin + ":list-extensions",
-                "-Dformat=id");
+                "-Dformat=id", withoutQuarkusRegistryClient());
         return extensions;
     }
 


### PR DESCRIPTION
Set `quarkusRegistryClient` to `false` for
`quarkus-maven-plugin:list-extensions` and
`quarkus-maven-plugin:create` commands.
The goal is to avoid errors when invoking the commands with productized
Maven repo which may try to resolve extension catalogs that are not
published yet.