### PR TITLE
Provide information when command fails

### DIFF
--- a/src/main/java/quarkus/extensions/combinator/utils/CommandBuilder.java
+++ b/src/main/java/quarkus/extensions/combinator/utils/CommandBuilder.java
@@ -87,6 +87,7 @@ public class CommandBuilder {
             Process process = run();
             int result = process.waitFor();
             if (result != 0) {
+                printFailedCommand(result);
                 throw new RuntimeException(description + " failed (executed " + command + ", return code " + result + ")");
             }
         } catch (Exception ex) {
@@ -97,6 +98,14 @@ public class CommandBuilder {
     private void printCommand() {
         String fullCommand = "Running: " + String.join(" ", command);
         LOG.info(fullCommand);
+        if (outputFile != null) {
+            FileUtils.appendLineIntoFile(fullCommand, outputFile);
+        }
+    }
+
+    private void printFailedCommand(int result) {
+        String fullCommand = "FAILED (return code " + result + ") when running: " + String.join(" ", command);
+        LOG.severe(fullCommand);
         if (outputFile != null) {
             FileUtils.appendLineIntoFile(fullCommand, outputFile);
         }


### PR DESCRIPTION
Provide information when command fails

Now we have to check target/failed.log file to see what combination fails

With this change we can look into console log to see early when things go down