### PR TITLE
Update native image builders - use version 22.2

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -187,8 +187,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        # Version 21.1 is not working due to https://github.com/quarkusio/quarkus/issues/14904
-        graalvm-version: [ "21.0.0.2.java11" ]
+        graalvm-version: ["22.2.0.java11"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1


### PR DESCRIPTION
Updates GraalVM/Mandrel version to 22.2. I think the https://github.com/quarkusio/quarkus/issues/14904 is fixed by now.