### PR TITLE
[2.13] backport: Exclude security-webauthn from QuarkusExtensionsCombination coverage

### DIFF
--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -119,3 +119,5 @@ logging-cloudwatch=skip-tests
 keycloak-authorization=skip-tests
 # https://jira.camunda.com/browse/CAM-14282
 camunda-bpm-quarkus-engine=skip-all
+# https://github.com/quarkusio/quarkus/issues/28746
+security-webauthn=skip-all


### PR DESCRIPTION
"security-webauthn" extension is not officially supported on 2.13 release

backport: b6a5763c5ab068e4b1dab8463c455618f9c7ac18 