### PR TITLE
Upstream issue: Exclude `security-webauthn` from QuarkusExtensionsCombination coverage

### DIFF
--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -119,3 +119,5 @@ logging-cloudwatch=skip-tests
 keycloak-authorization=skip-tests
 # https://jira.camunda.com/browse/CAM-14282
 camunda-bpm-quarkus-engine=skip-all
+# https://github.com/quarkusio/quarkus/issues/28746
+security-webauthn=skip-all


### PR DESCRIPTION
Related to: https://github.com/quarkusio/quarkus/issues/28746