### PR TITLE
Fix Amazon Lambda issue with random port - use dedicated property

### DIFF
--- a/src/main/java/quarkus/extensions/combinator/maven/MavenProject.java
+++ b/src/main/java/quarkus/extensions/combinator/maven/MavenProject.java
@@ -18,6 +18,7 @@ public class MavenProject extends MavenCommand {
     private static final String SKIP_INTEGRATION_TESTS = "-DskipITs";
     private static final String RANDOM_PORT_FOR_TESTS = "-Dquarkus.http.test-port=0";
     private static final String RANDOM_PORT_FOR_RUNNING = "-Dquarkus.http.port=0";
+    private static final String RANDOM_PORT_FOR_RUNNING_LAMBDA = "-Dquarkus.lambda.mock-event-server.test-port=0";
     private static final String XMX_MEMORY_LIMIT = "-Dquarkus.native.native-image-xmx=4g";
 
     private final File output;
@@ -43,7 +44,7 @@ public class MavenProject extends MavenCommand {
     }
 
     public MavenProject devMode() {
-        currentProcess = runMavenCommand(DEV_MODE, RANDOM_PORT_FOR_RUNNING, optionalSkipTests(),
+        currentProcess = runMavenCommand(DEV_MODE, RANDOM_PORT_FOR_RUNNING, RANDOM_PORT_FOR_RUNNING_LAMBDA, optionalSkipTests(),
                 optionalSkipITs());
         return this;
     }


### PR DESCRIPTION
If you run commands to reproduce from https://issues.redhat.com/browse/QUARKUS-1980 you will see that setting `quarkus.http.test-port` leads to an exception, Bill fixed it in a way that you have to use `quarkus.lambda.mock-event-server.test-port` in order to make it work (see https://github.com/quarkusio/quarkus/issues/23581#issuecomment-1043327890). Daily runs don't fail as lambda extensions are not Red Hat supported, however in Jenkins jobs lambdas are present. Combination of `quarkus.http.test-port` and `quarkus.lambda.mock-event-server.test-port` also works.