### PR TITLE
[2.13] Fix Amazon Lambda issue with random port - use dedicated property

### DIFF
--- a/src/main/java/quarkus/extensions/combinator/maven/MavenProject.java
+++ b/src/main/java/quarkus/extensions/combinator/maven/MavenProject.java
@@ -18,6 +18,7 @@ public class MavenProject extends MavenCommand {
     private static final String SKIP_INTEGRATION_TESTS = "-DskipITs";
     private static final String RANDOM_PORT_FOR_TESTS = "-Dquarkus.http.test-port=0";
     private static final String RANDOM_PORT_FOR_RUNNING = "-Dquarkus.http.port=0";
+    private static final String RANDOM_PORT_FOR_RUNNING_LAMBDA = "-Dquarkus.lambda.mock-event-server.test-port=0";
     private static final String XMX_MEMORY_LIMIT = "-Dquarkus.native.native-image-xmx=4g";
 
     private final File output;
@@ -43,7 +44,7 @@ public class MavenProject extends MavenCommand {
     }
 
     public MavenProject devMode() {
-        currentProcess = runMavenCommand(DEV_MODE, RANDOM_PORT_FOR_RUNNING, optionalSkipTests(),
+        currentProcess = runMavenCommand(DEV_MODE, RANDOM_PORT_FOR_RUNNING, RANDOM_PORT_FOR_RUNNING_LAMBDA, optionalSkipTests(),
                 optionalSkipITs());
         return this;
     }


### PR DESCRIPTION
Cherrypick of https://github.com/quarkus-qe/quarkus-extensions-combinations/pull/172/commits/f0fb611835230601a9505c16d8dd10e9f216208f