### PR TITLE
Align Lambda test port with HTTP test port

### DIFF
--- a/src/main/java/quarkus/extensions/combinator/maven/MavenGenerator.java
+++ b/src/main/java/quarkus/extensions/combinator/maven/MavenGenerator.java
@@ -52,7 +52,7 @@ public class MavenGenerator extends MavenCommand {
         updateApplicationProperties();
         dropEntityAnnotations();
         copyResources();
-        return new MavenProject(output, projectAsWorkingDirectory());
+        return new MavenProject(output, projectAsWorkingDirectory(), extensions);
     }
 
     @Override


### PR DESCRIPTION
I made mistake in https://github.com/quarkus-qe/quarkus-extensions-combinations/pull/172 we need to align Lambda test port with HTTP test port to fix our Jenkins jobs.

Also we need to append `-Dquarkus.lambda.mock-event-server.test-port=0` only if Amazon Lambda extension is present, as otherwise an exception is thrown. Normally I'd say it is a bug, but there is no easy and cheap way to resolve capabilities/extensions in `quarkus-test-common` AFAICT. It is not very useful thing to fix as most users will not specify test properties for extensions they don't have, or they can easily work around that.

In dev mode, no changes are required
```bash
quarkus create --extension amazon-lambda-http
cd code-with-quarkus/
mvn quarkus:dev -Dmaven.repo.local=/home/mvavrik/rhbq/rh-quarkus-2.13.4.GA-maven-repository/maven-repository/ -Dquarkus-plugin.version=2.13.4.Final-redhat-00004 -Dquarkus.platform.group-id=com.redhat.quarkus.platform -Dquarkus.platform.artifact-id=quarkus-bom verify -D-Dquarkus.http.port=0 -Dquarkus.platform.version=2.13.4.Final-redhat-00004
```