### PR TITLE
Bump Quarkus to 2.15.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>2.13.3.Final</quarkus.version>
+        <quarkus.version>2.15.1.Final</quarkus.version>
         <quarkus.ide-config.version>2.7.2.Final</quarkus.ide-config.version>
         <awaitility.version>4.2.0</awaitility.version>
         <rest-assured.version>5.3.0</rest-assured.version>


### PR DESCRIPTION
TS run against `2.15.0.Final`: https://main-jenkins-csb-quarkusqe.apps.ocp-c1.prod.psi.redhat.com/job/quarkus-main-rhel8-jdk11-extensions-combinations-ts/96/testReport/
- 25 combinations fail, need to be addressed separately.
- Previos run against `2.13.3.Final` for comparison - identical set of combinations fails: https://main-jenkins-csb-quarkusqe.apps.ocp-c1.prod.psi.redhat.com/job/quarkus-main-rhel8-jdk11-extensions-combinations-ts/95/testReport/.