### PR TITLE
GH actions update - latest maven, enable native

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,7 @@ jobs:
       matrix:
         java: [ 11 ]
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+      - uses: actions/checkout@v3
       - name: Install JDK {{ matrix.java }}
         uses: actions/setup-java@v3
         with:
@@ -23,10 +17,6 @@ jobs:
           java-version: ${{ matrix.java }}
           check-latest: true
           cache: 'maven'
-      - name: Set up Maven 3.8.7 #TODO: https://github.com/quarkusio/quarkus/issues/31011#issuecomment-1453522507
-        uses: stCarolas/setup-maven@v4.5
-        with:
-          maven-version: 3.8.7
       - name: Build with Maven
         run: mvn -s .github/mvn-settings.xml clean test -Dts.limit-extensions=1
       - name: Verify extension that needs special properties

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -11,26 +11,16 @@ jobs:
       TESTCONTAINERS_RYUK_DISABLED: true
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Install JDK {{ matrix.java }}
+      - uses: actions/checkout@v3
+      - name: Install JDK ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           check-latest: true
           cache: 'maven'
-      - name: Set up Maven 3.8.7 #TODO: https://github.com/quarkusio/quarkus/issues/31011#issuecomment-1453522507
-        uses: stCarolas/setup-maven@v4.5
-        with:
-          maven-version: 3.8.7
       - name: Run Test Suite
         run: mvn -s .github/mvn-settings.xml clean test -Dts.limit-extensions=200 -Dts.extensions-in-groups-of=2
       - name: Zip Artifacts
@@ -43,65 +33,34 @@ jobs:
         with:
           name: ci-artifacts
           path: artifacts-linux-jvm${{ matrix.java }}.zip
-  linux-build-released-dev:
-    name: Linux - DEV build - released Quarkus
-    needs: [ linux-build-released-jvm ]
-    if: false # always skip job as it's failing due to memory requirements
-    runs-on: ubuntu-latest
-    env:
-      TESTCONTAINERS_RYUK_DISABLED: true
-    strategy:
-      matrix:
-        java: [ 11 ]
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Install JDK {{ matrix.java }}
-        # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
-        with:
-          java-version: openjdk${{ matrix.java }}
-      - name: Run Test Suite
-        run: mvn -s .github/mvn-settings.xml clean test -Dts.limit-extensions=20 -Dts.extensions-in-groups-of=10 -Dts.verify-dev-mode=true -Ddisable-parallel
-      - name: Zip Artifacts
-        if: failure()
-        run: |
-          zip -r artifacts-linux-dev${{ matrix.java }}.zip . -i '**/*-reports/*.xml' '**/*.log'
-      - name: Archive artifacts
-        if: failure()
-        uses: actions/upload-artifact@v1
-        with:
-          name: ci-artifacts
-          path: artifacts-linux-dev${{ matrix.java }}.zip
   linux-build-released-native:
     name: Linux - Native build - released Quarkus
-    needs: [ linux-build-released-dev ]
     runs-on: ubuntu-latest
     env:
       TESTCONTAINERS_RYUK_DISABLED: true
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
+        graalvm-version: ["22.3.2"]
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v3
+      - name: Install JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Install JDK {{ matrix.java }}
-        # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          check-latest: true
+          cache: 'maven'
+      - name: Setup GraalVM
+        id: setup-graalvm
+        uses: graalvm/setup-graalvm@v1
         with:
-          java-version: openjdk${{ matrix.java }}
+          version: ${{ matrix.graalvm-version }}
+          java-version: ${{ matrix.java }}
+          components: 'native-image'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Test Suite
-        run: mvn -s .github/mvn-settings.xml clean test -Dts.limit-extensions=5 -Dts.extensions-in-groups-of=25 -Dts.verify-native-mode=true -Ddisable-parallel
+        run: mvn -e -s .github/mvn-settings.xml clean test -Dts.limit-extensions=20 -Dts.extensions-in-groups-of=5 -Dts.verify-native-mode=true -Ddisable-parallel
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -119,20 +78,16 @@ jobs:
       TESTCONTAINERS_RYUK_DISABLED: true
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v3
+      - name: Install JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Setup Java and Maven
-        uses: s4u/setup-maven-action@v1.6.0
-        with:
-          maven-version: 3.8.7
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          check-latest: true
+          cache: 'maven'
       - name: Run Test Suite
         shell: bash
         run: mvn -s .github/mvn-settings.xml clean test -Dts.limit-extensions=200 -Dts.extensions-in-groups-of=2 -Dformat.skip=true
@@ -148,84 +103,49 @@ jobs:
         with:
           name: ci-artifacts
           path: artifacts-windows-jvm${{ matrix.java }}.tar
-  windows-build-released-dev:
-    name: Windows - DEV build - released Quarkus
-    needs: [ windows-build-released-jvm ]
-    if: false # always skip job as it's failing due to memory requirements
-    runs-on: windows-latest
-    env:
-      TESTCONTAINERS_RYUK_DISABLED: true
-    strategy:
-      matrix:
-        java: [ 11 ]
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
-        with:
-          java-version: ${{ matrix.java }}
-      - name: Run Test Suite
-        shell: bash
-        run: mvn -s .github/mvn-settings.xml clean test -Dts.limit-extensions=20 -Dts.extensions-in-groups-of=10 -Dts.verify-dev-mode=true -Dformat.skip=true -Ddisable-parallel
-      - name: Zip Artifacts
-        if: failure()
-        shell: bash
-        run: |
-          # Disambiguate windows find from cygwin find
-          /usr/bin/find . -print | grep -e "-reports" -e ".log" | grep -v "git" | tar -czf artifacts-windows-jvm${{ matrix.java }}.tar -T -
-      - name: Archive artifacts
-        uses: actions/upload-artifact@v1
-        if: failure()
-        with:
-          name: ci-artifacts
-          path: artifacts-windows-dev${{ matrix.java }}.tar
   windows-build-released-native:
     name: Windows - Native build - released Quarkus
-    needs: [ windows-build-released-dev ]
     runs-on: windows-latest
     env:
       TESTCONTAINERS_RYUK_DISABLED: true
     strategy:
       matrix:
-        java: [ 11 ]
-        graalvm-version: ["22.2.0.java11"]
+        java: [ 17 ]
+        graalvm-version: ["22.3.2"]
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v3
+      - name: Install JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
-        with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          check-latest: true
+          cache: 'maven'
       - name: Install cl.exe
         uses: ilammy/msvc-dev-cmd@v1
       - uses: microsoft/setup-msbuild@v1
       - name: Setup GraalVM
         id: setup-graalvm
-        uses: DeLaGuardo/setup-graalvm@master
+        uses: graalvm/setup-graalvm@v1
         with:
-          graalvm-version: ${{ matrix.graalvm-version }}
-          java: java${{ matrix.graalvm-version }}
+          version: ${{ matrix.graalvm-version }}
+          java-version: ${{ matrix.java }}
+          components: 'native-image'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install native-image component
         run: |
           gu.cmd install native-image
       - name: Configure Pagefile
         # Increased the page-file size due to memory-consumption of native-image command
         # For details see https://github.com/actions/virtual-environments/issues/785
-        uses: al-cheb/configure-pagefile-action@v1.2
+        uses: al-cheb/configure-pagefile-action@v1.3
       - name: Run Test Suite
         shell: cmd
-        run: mvn -s .github/mvn-settings.xml clean test -Dts.limit-extensions=5 -Dts.extensions-in-groups-of=25 -Dts.verify-native-mode=true -Dformat.skip=true -Ddisable-parallel
+        # Windows have path limits and thus ts.extensions-in-groups-of is set to 1, generated app name is based on the extensions names
+        # Otherwise native-image command throws errors
+        # [ERROR] ...  CreateProcess error=267, The directory name is invalid
+        # Fatal error: java.lang.RuntimeException: There was an error linking the native image: Linker command exited with 2
+        run: mvn -e -s .github/mvn-settings.xml clean test -Dts.limit-extensions=20 -Dts.extensions-in-groups-of=1 -Dts.verify-native-mode=true -Dformat.skip=true -Ddisable-parallel
       - name: Zip Artifacts
         if: failure()
         shell: bash

--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -70,6 +70,8 @@ resteasy-multipart,spring-web=skip-all
 resteasy-reactive,oidc-client-filter=skip-all
 spring-web,oidc-client-filter=skip-all
 spring-web,rest-client-jsonb=skip-all
+spring-web,rest-client-jaxb=skip-all
+spring-web,rest-client=skip-all
 ## Resteasy Reactive extension with extensions using Resteasy Classic:
 resteasy-reactive,rest-client=skip-all
 resteasy-reactive,rest-client-jackson=skip-all

--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -18,7 +18,8 @@ jdbc-mssql=skip-only-tests-on-windows
 jdbc-mysql=skip-only-tests-on-windows
 jdbc-postgresql=skip-only-tests-on-windows
 jooq=skip-all
-kafka-client=skip-only-tests-on-windows
+# https://github.com/quarkusio/quarkus/issues/32968
+kafka-client=skip-all
 # It needs keycloak
 keycloak-authorization=skip-tests
 # It needs AWS account
@@ -68,6 +69,7 @@ resteasy-jsonb,spring-web=skip-all
 resteasy-multipart,spring-web=skip-all
 resteasy-reactive,oidc-client-filter=skip-all
 spring-web,oidc-client-filter=skip-all
+spring-web,rest-client-jsonb=skip-all
 ## Resteasy Reactive extension with extensions using Resteasy Classic:
 resteasy-reactive,rest-client=skip-all
 resteasy-reactive,rest-client-jackson=skip-all
@@ -142,14 +144,10 @@ resteasy-reactive-qute,resteasy-jaxb=skip-all
 resteasy-reactive-qute,resteasy-jackson=skip-all
 resteasy-reactive-qute,resteasy-multipart=skip-all
 ## REST Data Panache can only work if 'quarkus-resteasy' or 'quarkus-resteasy-reactive' is present
-spring-data-rest,oidc-client-reactive-filter=skip-all
-spring-data-rest,oidc-client-filter=skip-all
-spring-data-rest,rest-client-jaxb=skip-all
-spring-data-rest,rest-client-jsonb=skip-all
-spring-data-rest,rest-client-jackson=skip-all
-spring-data-rest,rest-client=skip-all
+spring-data-rest=skip-all
 hibernate-orm-rest-data-panache,oidc-client-reactive-filter=skip-all
 hibernate-orm-rest-data-panache,oidc-client-filter=skip-all
+hibernate-orm-rest-data-panache,oidc-client=skip-all
 hibernate-orm-rest-data-panache,rest-client-jaxb=skip-all
 hibernate-orm-rest-data-panache,rest-client-jsonb=skip-all
 hibernate-orm-rest-data-panache,rest-client-jackson=skip-all

--- a/src/main/resources/jdbc-mssql/container-license-acceptance.txt
+++ b/src/main/resources/jdbc-mssql/container-license-acceptance.txt
@@ -1,1 +1,2 @@
 mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
+mcr.microsoft.com/mssql/server:2019-latest

--- a/src/main/resources/reactive-mssql-client/container-license-acceptance.txt
+++ b/src/main/resources/reactive-mssql-client/container-license-acceptance.txt
@@ -1,1 +1,2 @@
 mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
+mcr.microsoft.com/mssql/server:2019-latest


### PR DESCRIPTION
GH actions update - latest maven, enabled native, exclusions updates.

Native mode enabled for Windows and Linux. Windows has limitations due to path length restrictions.

Native part of daily runs were executed in 10+ run (see `.` commits in this PR history, edit: switch from draft to full PR dropped the history of commits ... ) to find all the troubles (exclusions, license agreements, Windows path limits), here is example from the last iteration:
<img width="889" alt="Screenshot 2023-04-28 at 8 37 35" src="https://user-images.githubusercontent.com/925259/235074713-38227f5b-2ac5-473f-9e27-38f3f3f89875.png">
