### PR TITLE
Bump to Quarkus 3.0.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>3.0.1.Final</quarkus.version>
+        <quarkus.version>3.0.4.Final</quarkus.version>
         <quarkus.ide-config.version>2.7.2.Final</quarkus.ide-config.version>
         <awaitility.version>4.2.0</awaitility.version>
         <rest-assured.version>5.3.0</rest-assured.version>

--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -18,7 +18,7 @@ jdbc-mssql=skip-only-tests-on-windows
 jdbc-mysql=skip-only-tests-on-windows
 jdbc-postgresql=skip-only-tests-on-windows
 jooq=skip-all
-# https://github.com/quarkusio/quarkus/issues/32968
+# https://github.com/quarkusio/quarkus/issues/32968, regression: https://github.com/quarkusio/quarkus/issues/33623
 kafka-client=skip-all
 # It needs keycloak
 keycloak-authorization=skip-tests
@@ -150,5 +150,3 @@ spring-data-rest=skip-all
 hibernate-orm-rest-data-panache=skip-all
 ## Spring Web can only work if 'quarkus-resteasy-jackson' or 'quarkus-resteasy-reactive-jackson' is present
 funqy-knative-events,spring-web=skip-all
-## https://github.com/quarkusio/quarkus/issues/33547
-infinispan-client,micrometer=skip-all


### PR DESCRIPTION
Update exclusions:
- https://github.com/quarkusio/quarkus/issues/33547 resolved.
- https://github.com/quarkusio/quarkus/issues/32968 is closed, but regressio reported in https://github.com/quarkusio/quarkus/issues/33623.