### PR TITLE
Exclusions for kind and google-cloud-functions

### DIFF
--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -150,3 +150,8 @@ spring-data-rest=skip-all
 hibernate-orm-rest-data-panache=skip-all
 ## Spring Web can only work if 'quarkus-resteasy-jackson' or 'quarkus-resteasy-reactive-jackson' is present
 funqy-knative-events,spring-web=skip-all
+## kind extension needs 'kind' tool available
+kind=skip-all
+## https://github.com/quarkusio/quarkus/issues/35476
+google-cloud-functions=skip-all
+funqy-google-cloud-functions=skip-all


### PR DESCRIPTION
Exclusions for kind and google-cloud-functions.

These extensions are community only, no concerns for product.