### PR TITLE
Exclusions for oidc-token-propagation-reactive and oidc-client-reactive-filter with Resteasy Classic

### DIFF
--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -119,6 +119,28 @@ resteasy-reactive-jsonb,resteasy-jaxb=skip-all
 resteasy-reactive-jsonb,resteasy-jsonb=skip-all
 resteasy-reactive-jsonb,resteasy-multipart=skip-all
 resteasy-reactive-jsonb,undertow=skip-all
+## Resteasy Reactive OIDC client filter extensions with extensions using Resteasy Classic:
+oidc-client-reactive-filter,rest-client=skip-all
+oidc-client-reactive-filter,rest-client-jackson=skip-all
+oidc-client-reactive-filter,rest-client-jaxb=skip-all
+oidc-client-reactive-filter,rest-client-jsonb=skip-all
+oidc-client-reactive-filter,resteasy=skip-all
+oidc-client-reactive-filter,resteasy-jackson=skip-all
+oidc-client-reactive-filter,resteasy-jaxb=skip-all
+oidc-client-reactive-filter,resteasy-jsonb=skip-all
+oidc-client-reactive-filter,resteasy-multipart=skip-all
+oidc-client-reactive-filter,oidc-client-filter=skip-all
+## Resteasy Reactive OIDC token propagation extensions with extensions using Resteasy Classic:
+oidc-token-propagation-reactive,rest-client=skip-all
+oidc-token-propagation-reactive,rest-client-jackson=skip-all
+oidc-token-propagation-reactive,rest-client-jaxb=skip-all
+oidc-token-propagation-reactive,rest-client-jsonb=skip-all
+oidc-token-propagation-reactive,resteasy=skip-all
+oidc-token-propagation-reactive,resteasy-jackson=skip-all
+oidc-token-propagation-reactive,resteasy-jaxb=skip-all
+oidc-token-propagation-reactive,resteasy-jsonb=skip-all
+oidc-token-propagation-reactive,resteasy-multipart=skip-all
+oidc-token-propagation-reactive,oidc-token-propagation=skip-all
 # https://github.com/quarkusio/quarkus/issues/28746
 security-webauthn=skip-all
 # Multiple producers of item class io.quarkus.deployment.metrics.MetricsCapabilityBuildItem
@@ -139,6 +161,8 @@ resteasy-qute,resteasy-reactive-jaxb=skip-all
 resteasy-qute,resteasy-reactive-jackson=skip-all
 resteasy-qute,resteasy-reactive-qute=skip-all
 resteasy-qute,spring-web=skip-all
+resteasy-qute,oidc-client-reactive-filter=skip-all
+resteasy-qute,oidc-token-propagation-reactive=skip-all
 ## RESTEasy Reactive Qute with extensions using RESTEasy Classic:
 resteasy-reactive-qute,resteasy=skip-all
 resteasy-reactive-qute,resteasy-jsonb=skip-all


### PR DESCRIPTION
Exclusions for oidc-token-propagation-reactive and oidc-client-reactive-filter with Resteasy Classic

Motivation: https://github.com/quarkus-qe/quarkus-extensions-combinations/actions/runs/6397970415