### PR TITLE
Change mandrel version in CI

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         java: [ 17 ]
-        graalvm-version: ["mandrel-latest"]
+        graalvm-version: ["mandrel-23.0.1.2-Final"]
     steps:
       - uses: actions/checkout@v3
       - name: Install JDK ${{ matrix.java }}
@@ -112,7 +112,7 @@ jobs:
     strategy:
       matrix:
         java: [ 17 ]
-        graalvm-version: ["mandrel-latest"]
+        graalvm-version: ["mandrel-23.0.1.2-Final"]
     steps:
       - uses: actions/checkout@v3
       - name: Install JDK ${{ matrix.java }}


### PR DESCRIPTION
Change CI definition from latest mandrel version to specific version (23.0.1.2-Final) as the newest one was built only by JDK 21.