### PR TITLE
Fix Some windows test are failing due to mvn.cmd return 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,8 @@
                     </systemPropertyVariables>
                     <properties>
                         <configurationParameters>junit.jupiter.execution.parallel.enabled = true
-                            <!-- Execute top-level classes in sequentially but their methods in parallel -->junit.jupiter.execution.parallel.mode.default = concurrent junit.jupiter.execution.parallel.mode.classes.default = same_thread
+                            <!-- Execute top-level classes in sequentially but their methods in parallel -->junit.jupiter.execution.parallel.mode.default = concurrent
+                            junit.jupiter.execution.parallel.mode.classes.default = same_thread
                         </configurationParameters>
                     </properties>
                     <!-- Configure Display name accordingly -->

--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -36,6 +36,7 @@ oidc=skip-only-tests-on-windows
 reactive-mysql-client=skip-only-tests-on-windows
 # Extensions that use testscontainers are currently not supported by Windows
 reactive-pg-client=skip-only-tests-on-windows
+kubernetes-config=skip-only-tests-on-windows
 rest-client-jackson,spring-web=skip-all
 rest-client-reactive,oidc-client-filter=skip-all
 ## Rest Client Reactive extension with extensions using Resteasy Classic:


### PR DESCRIPTION
Fixing daily as test combination using `kubernetes-config` with combination of some extension failing (some combination skipping test already/there are no tests). `Kubernetes-config` need testcontainers which are not supported on windows.

Testing this with around 20 runs and it's not failing anymore, and the `kubernetes-config` appearing in some combination.

 Also in log there was warning as `junit.jupiter.execution.parallel.mode.default = concurrent` and `junit.jupiter.execution.parallel.mode.classes.default = same_thread` was on same row so it was unknown mode.

Maybe this should be backported to 3.2?