### PR TITLE
Add licence acceptance for mssql 2022

### DIFF
--- a/src/main/resources/jdbc-mssql/container-license-acceptance.txt
+++ b/src/main/resources/jdbc-mssql/container-license-acceptance.txt
@@ -1,2 +1,3 @@
 mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-latest
+mcr.microsoft.com/mssql/server:2022-latest

--- a/src/main/resources/reactive-mssql-client/container-license-acceptance.txt
+++ b/src/main/resources/reactive-mssql-client/container-license-acceptance.txt
@@ -1,2 +1,3 @@
 mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-latest
+mcr.microsoft.com/mssql/server:2022-latest


### PR DESCRIPTION
Add mssql 2022 to accepted licences. By personal testing it's added by `hibernate-search-orm-elasticsearch` and `hibernate-orm` so maybe all hibernate extensions pulling it (not tested). 
This probably not show on every run but I do like 20 run and no error. There was few which have combination of mssql and hibernate and it work. Locally tested these commands and it failed with missing licence so it should be fine now. 