### PR TITLE
Propagate quarkusRegistryClient property

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -61,7 +61,7 @@ jobs:
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Test Suite
-        run: mvn -e -s .github/mvn-settings.xml clean test -Dts.limit-extensions=20 -Dts.extensions-in-groups-of=5 -Dts.verify-native-mode=true -Ddisable-parallel
+        run: mvn -e -s .github/mvn-settings.xml clean test -Dts.limit-extensions=20 -Dts.extensions-in-groups-of=4 -Dts.verify-native-mode=true -Ddisable-parallel
       - name: Zip Artifacts
         if: failure()
         run: |

--- a/src/main/java/quarkus/extensions/combinator/maven/MavenCommand.java
+++ b/src/main/java/quarkus/extensions/combinator/maven/MavenCommand.java
@@ -21,9 +21,9 @@ public abstract class MavenCommand {
     private static final String QUARKUS_PLATFORM_VERSION = "quarkus.platform.version";
     private static final String QUARKUS_PLATFORM_GROUP_ID = "quarkus.platform.group-id";
     private static final String QUARKUS_PLATFORM_ARTIFACT_ID = "quarkus.platform.artifact-id";
-    private static final List<String> PROPERTIES_TO_PROPAGATE = Arrays.asList(MAVEN_REPO_LOCAL, QUARKUS_PLUGIN_VERSION,
-            QUARKUS_PLATFORM_VERSION, QUARKUS_PLATFORM_GROUP_ID, QUARKUS_PLATFORM_ARTIFACT_ID);
     private static final String QUARKUS_REGISTRY_CLIENT = "quarkusRegistryClient";
+    private static final List<String> PROPERTIES_TO_PROPAGATE = Arrays.asList(MAVEN_REPO_LOCAL, QUARKUS_PLUGIN_VERSION,
+            QUARKUS_PLATFORM_VERSION, QUARKUS_PLATFORM_GROUP_ID, QUARKUS_PLATFORM_ARTIFACT_ID, QUARKUS_REGISTRY_CLIENT);
 
     private final File workingDirectory;
 
@@ -53,10 +53,6 @@ public abstract class MavenCommand {
 
     protected String withProperty(String property, String value) {
         return String.format("-D%s=%s", property, value);
-    }
-
-    protected String withoutQuarkusRegistryClient() {
-        return withProperty(QUARKUS_REGISTRY_CLIENT, "false");
     }
 
     private CommandBuilder configureMavenCommand(String[] params) {

--- a/src/main/java/quarkus/extensions/combinator/maven/MavenGenerator.java
+++ b/src/main/java/quarkus/extensions/combinator/maven/MavenGenerator.java
@@ -48,7 +48,7 @@ public class MavenGenerator extends MavenCommand {
         FileUtils.deleteDirectory(projectAsWorkingDirectory());
 
         runMavenCommandAndWait(withQuarkusPluginCreate(), withProjectGroupId(), withProjectArtifactId(), withProjectVersion(),
-                withPlatformGroupId(), withPlatformArtifactId(), withExtensions(), withoutQuarkusRegistryClient());
+                withPlatformGroupId(), withPlatformArtifactId(), withExtensions());
         updateApplicationProperties();
         dropEntityAnnotations();
         copyResources();

--- a/src/main/java/quarkus/extensions/combinator/maven/MavenGetQuarkusExtensions.java
+++ b/src/main/java/quarkus/extensions/combinator/maven/MavenGetQuarkusExtensions.java
@@ -14,7 +14,7 @@ public class MavenGetQuarkusExtensions extends MavenCommand {
         extensions.clear();
         String quarkusMavenPlugin = getQuarkusMavenPlugin();
         runMavenCommandAndWait("-f", "target/test-classes/list-extensions.pom.xml", quarkusMavenPlugin + ":list-extensions",
-                "-Dformat=id", withoutQuarkusRegistryClient());
+                "-Dformat=id");
         return extensions;
     }
 

--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -8,6 +8,8 @@ camel-quarkus-jpa=skip-all
 # It needs JMX configuration
 camel-quarkus-sjms=skip-all
 camel-quarkus-sjms2=skip-all
+# It needs a datasource (no workaround like quarkus.datasource.jdbc=false)
+camel-quarkus-mybatis=skip-all
 # https://jira.camunda.com/browse/CAM-14282
 camunda-bpm-quarkus-engine=skip-all
 debezium-quarkus-outbox=skip-all
@@ -22,6 +24,8 @@ jooq=skip-all
 kafka-client=skip-all
 # It needs keycloak
 keycloak-authorization=skip-tests
+# There is a name collision between io.quarkus:quarkus-logging-json and io.quarkiverse.loggingjson:quarkus-logging-json
+logging-json=skip-all
 # It needs AWS account
 logging-cloudwatch=skip-tests
 # It requires external Maven repository


### PR DESCRIPTION
The property tells Quarkus Maven Plugin whether it should use the online registry to resolve extension catalog. Default is `true` for Quarkus. Thanks to the propagation, it can now be overriden when running tests by using `-DquarkusRegistryClient=false`.

Fixes
https://github.com/quarkus-qe/quarkus-extensions-combinations/issues/115.

Additional fixes:
- Decrease combinations size in native GH test
  - To avoid OutOfMemoryError for increased number of extensions (174 at the
moment).
- Exclude camel-quarkus-mybatis and logging-json
  - `camel-quarkus-mybatis` needs a datasource.
  - There is a name collision between `io.quarkus:quarkus-logging-json` and `io.quarkiverse.loggingjson:quarkus-logging-json`.