### PR TITLE
Add dev and native exclusions, exclude camel-quarkus-fhir in native

### DIFF
--- a/src/main/java/quarkus/extensions/combinator/exclusions/ExclusionsManager.java
+++ b/src/main/java/quarkus/extensions/combinator/exclusions/ExclusionsManager.java
@@ -14,15 +14,19 @@ import quarkus.extensions.combinator.utils.OsUtils;
 
 public class ExclusionsManager {
 
-    public static final ExclusionsManager EXCLUSIONS_MANAGER = new ExclusionsManager();
+    private static final ExclusionsManager EXCLUSIONS_MANAGER = new ExclusionsManager();
 
     private static final Logger LOG = Logger.getLogger(ExclusionsManager.class.getName());
     private static final String EXCLUSIONS_FILE = "exclusions.properties";
     private static final String SKIP_ALL_VALUE = "skip-all";
+    private static final String SKIP_DEV_MODE_VALUE = "skip-dev";
+    private static final String SKIP_NATIVE_MODE_VALUE = "skip-native";
     private static final String SKIP_TESTS_VALUE = "skip-tests";
     private static final String SKIP_TESTS_ON_WINDOWS = "skip-only-tests-on-windows";
 
     private final List<Set<String>> skipCombinations = new ArrayList<>();
+    private final List<Set<String>> skipDevModeCombinations = new ArrayList<>();
+    private final List<Set<String>> skipNativeModeCombinations = new ArrayList<>();
     private final List<Set<String>> skipTestsCombinations = new ArrayList<>();
     private final List<Set<String>> skipTestsOnWindowsCombinations = new ArrayList<>();
 
@@ -33,6 +37,16 @@ public class ExclusionsManager {
     public boolean isNotExcluded(Set<String> combination) {
         return skipCombinations.isEmpty()
                 || !skipCombinations.stream().anyMatch(excluded -> combination.containsAll(excluded));
+    }
+
+    public boolean isDevModeDisabled(Set<String> combination) {
+        return !skipDevModeCombinations.isEmpty()
+                && skipDevModeCombinations.stream().anyMatch(excluded -> combination.containsAll(excluded));
+    }
+
+    public boolean isNativeModeDisabled(Set<String> combination) {
+        return !skipNativeModeCombinations.isEmpty()
+                && skipNativeModeCombinations.stream().anyMatch(excluded -> combination.containsAll(excluded));
     }
 
     public boolean isTestsDisabled(Set<String> combination) {
@@ -58,6 +72,10 @@ public class ExclusionsManager {
                 Set<String> combination = Stream.of(((String) entry.getKey()).split(",")).collect(Collectors.toSet());
                 if (SKIP_ALL_VALUE.equalsIgnoreCase(rule)) {
                     skipCombinations.add(combination);
+                } else if (SKIP_DEV_MODE_VALUE.equalsIgnoreCase(rule)) {
+                    skipDevModeCombinations.add(combination);
+                } else if (SKIP_NATIVE_MODE_VALUE.equalsIgnoreCase(rule)) {
+                    skipNativeModeCombinations.add(combination);
                 } else if (SKIP_TESTS_VALUE.equalsIgnoreCase(rule)) {
                     skipTestsCombinations.add(combination);
                 } else if (SKIP_TESTS_ON_WINDOWS.equalsIgnoreCase(rule)) {

--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -38,6 +38,8 @@ mybatis=skip-all
 narayana-lra=skip-all
 oidc=skip-only-tests-on-windows
 reactive-mysql-client=skip-only-tests-on-windows
+# camel-quarkus-fhir exceeds the -Dquarkus.native.native-image-xmx=4g limit
+camel-quarkus-fhir=skip-native
 # Extensions that use testscontainers are currently not supported by Windows
 reactive-pg-client=skip-only-tests-on-windows
 kubernetes-config=skip-only-tests-on-windows

--- a/src/test/java/quarkus/extensions/combinator/QuarkusExtensionsCombinationTest.java
+++ b/src/test/java/quarkus/extensions/combinator/QuarkusExtensionsCombinationTest.java
@@ -36,12 +36,12 @@ class QuarkusExtensionsCombinationTest {
 
         project.verify();
 
-        if (Configuration.VERIFY_DEV_MODE.getAsBoolean()) {
+        if (Configuration.VERIFY_DEV_MODE.getAsBoolean() && !ExclusionsManager.get().isDevModeDisabled(extensions)) {
             project.devMode();
             assertApplicationInDevMode(project);
         }
 
-        if (Configuration.VERIFY_NATIVE_MODE.getAsBoolean()) {
+        if (Configuration.VERIFY_NATIVE_MODE.getAsBoolean() && !ExclusionsManager.get().isNativeModeDisabled(extensions)) {
             project.nativeMode();
         }
 

--- a/src/test/java/quarkus/extensions/combinator/extensions/ExtensionsProvider.java
+++ b/src/test/java/quarkus/extensions/combinator/extensions/ExtensionsProvider.java
@@ -77,7 +77,7 @@ public final class ExtensionsProvider implements ArgumentsProvider {
         return combination -> {
             List<String> includesExtensions = Configuration.INCLUDES_COMBINATIONS_ONLY_WITH_EXTENSIONS.getAsList();
             return includesExtensions.isEmpty()
-                    || includesExtensions.stream().allMatch(extension -> combination.contains(extension));
+                    || includesExtensions.stream().anyMatch(extension -> combination.contains(extension));
         };
     }
 


### PR DESCRIPTION
`camel-quarkus-fhir` exceeds the `-Dquarkus.native.native-image-xmx=4g` limit.