### PR TITLE
Bump Quarkus from 3.5 to 3.6, introduce weekly run with the whole platform

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -23,7 +23,7 @@ jobs:
           check-latest: true
           cache: 'maven'
       - name: Run Test Suite
-        run: mvn -s .github/mvn-settings.xml clean test -Dts.limit-extensions=200 -Dts.extensions-in-groups-of=2
+        run: mvn -ntp -s .github/mvn-settings.xml clean test -DquarkusRegistryClient=false -Dts.limit-extensions=200 -Dts.extensions-in-groups-of=2
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -61,7 +61,7 @@ jobs:
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Test Suite
-        run: mvn -e -s .github/mvn-settings.xml clean test -Dts.limit-extensions=20 -Dts.extensions-in-groups-of=4 -Dts.verify-native-mode=true -Ddisable-parallel
+        run: mvn -ntp -e -s .github/mvn-settings.xml clean test -DquarkusRegistryClient=false -Dts.limit-extensions=20 -Dts.extensions-in-groups-of=5 -Dts.verify-native-mode=true -Ddisable-parallel
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -91,7 +91,7 @@ jobs:
           cache: 'maven'
       - name: Run Test Suite
         shell: bash
-        run: mvn -s .github/mvn-settings.xml clean test -Dts.limit-extensions=200 -Dts.extensions-in-groups-of=2 -Dformat.skip=true
+        run: mvn -ntp -s .github/mvn-settings.xml clean test -DquarkusRegistryClient=false -Dts.limit-extensions=200 -Dts.extensions-in-groups-of=2 -Dformat.skip=true
       - name: Zip Artifacts
         if: failure()
         shell: bash
@@ -143,7 +143,7 @@ jobs:
         # Otherwise native-image command throws errors
         # [ERROR] ...  CreateProcess error=267, The directory name is invalid
         # Fatal error: java.lang.RuntimeException: There was an error linking the native image: Linker command exited with 2
-        run: mvn -e -s .github/mvn-settings.xml clean test -Dts.limit-extensions=20 -Dts.extensions-in-groups-of=1 -Dts.verify-native-mode=true -Dformat.skip=true -Ddisable-parallel
+        run: mvn -ntp -e -s .github/mvn-settings.xml clean test -DquarkusRegistryClient=false -Dts.limit-extensions=20 -Dts.extensions-in-groups-of=1 -Dts.verify-native-mode=true -Dformat.skip=true -Ddisable-parallel
       - name: Zip Artifacts
         if: failure()
         shell: bash

--- a/.github/workflows/weekly-with-registry.yml
+++ b/.github/workflows/weekly-with-registry.yml
@@ -1,0 +1,73 @@
+name: "Weekly Build with All Extensions from Registry"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 18 * * 6'
+jobs:
+  linux-build-released-jvm:
+    name: Linux - JVM build - released Quarkus
+    runs-on: ubuntu-latest
+    env:
+      TESTCONTAINERS_RYUK_DISABLED: true
+    strategy:
+      matrix:
+        java: [ 17 ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          check-latest: true
+          cache: 'maven'
+      - name: Run Test Suite
+        run: mvn -ntp -s .github/mvn-settings.xml clean test -Dts.limit-extensions=200 -Dts.extensions-in-groups-of=2
+      - name: Zip Artifacts
+        if: failure()
+        run: |
+          zip -r artifacts-linux-jvm${{ matrix.java }}.zip . -i '**/*-reports/*.xml' '**/*.log'
+      - name: Archive artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1
+        with:
+          name: ci-artifacts
+          path: artifacts-linux-jvm${{ matrix.java }}.zip
+  linux-build-released-native:
+    name: Linux - Native build - released Quarkus
+    runs-on: ubuntu-latest
+    env:
+      TESTCONTAINERS_RYUK_DISABLED: true
+    strategy:
+      matrix:
+        java: [ 17 ]
+        graalvm-version: ["mandrel-23.0.1.2-Final"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          check-latest: true
+          cache: 'maven'
+      - name: Setup GraalVM
+        id: setup-graalvm
+        uses: graalvm/setup-graalvm@v1
+        with:
+          version: ${{ matrix.graalvm-version }}
+          java-version: ${{ matrix.java }}
+          components: 'native-image'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run Test Suite
+        run: mvn -ntp -e -s .github/mvn-settings.xml clean test -Dts.limit-extensions=20 -Dts.extensions-in-groups-of=4 -Dts.verify-native-mode=true -Ddisable-parallel
+      - name: Zip Artifacts
+        if: failure()
+        run: |
+          zip -r artifacts-linux-native${{ matrix.java }}.zip . -i '**/*-reports/*.xml' '**/*.log'
+      - name: Archive artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1
+        with:
+          name: ci-artifacts
+          path: artifacts-linux-native${{ matrix.java }}.zip

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>3.5.0</quarkus.version>
+        <quarkus.version>3.6.0</quarkus.version>
         <awaitility.version>4.2.0</awaitility.version>
         <rest-assured.version>5.3.0</rest-assured.version>
         <surefire-plugin.version>3.2.2</surefire-plugin.version>


### PR DESCRIPTION
Bump Quarkus from 3.5 to 3.6, introduce weekly run with the whole platform

Daily run to use just core extensions, weekly run to use extensions from the whole platform

Daily run uses -DquarkusRegistryClient=false to limit the number of checked extensions to the core ones, weekly run fetches list of extensions from registry