### PR TITLE
Bump Quarkus from 3.6.0 to 3.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>3.6.0</quarkus.version>
+        <quarkus.version>3.6.1</quarkus.version>
         <awaitility.version>4.2.0</awaitility.version>
         <rest-assured.version>5.3.0</rest-assured.version>
         <surefire-plugin.version>3.2.2</surefire-plugin.version>


### PR DESCRIPTION
Bump Quarkus from 3.6.0 to 3.6.1

3.6.1 contains backport of https://github.com/quarkusio/quarkus/pull/37247