### PR TITLE
google-cloud-functions allow using a random test port

### DIFF
--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -183,6 +183,3 @@ hibernate-orm-rest-data-panache=skip-all
 funqy-knative-events,spring-web=skip-all
 ## kind extension needs 'kind' tool available
 kind=skip-all
-## https://github.com/quarkusio/quarkus/issues/35476
-google-cloud-functions=skip-all
-funqy-google-cloud-functions=skip-all


### PR DESCRIPTION
google-cloud-functions allow using a random test port since 3.6.0

Issue reference: https://github.com/quarkusio/quarkus/issues/35476