### PR TITLE
Add ext list cmd retry and logging for failed command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,10 +164,8 @@
                         <quarkus.version>${quarkus.version}</quarkus.version>
                     </systemPropertyVariables>
                     <properties>
-                        <configurationParameters>junit.jupiter.execution.parallel.enabled = true
-                            <!-- Execute top-level classes in sequentially but their methods in parallel -->junit.jupiter.execution.parallel.mode.default = concurrent
-                            junit.jupiter.execution.parallel.mode.classes.default = same_thread
-                        </configurationParameters>
+                        <!-- Execute top-level classes in sequentially but their methods in parallel -->
+                        <configurationParameters>junit.jupiter.execution.parallel.enabled = true junit.jupiter.execution.parallel.mode.default = concurrent junit.jupiter.execution.parallel.mode.classes.default = same_thread</configurationParameters>
                     </properties>
                     <!-- Configure Display name accordingly -->
                     <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">

--- a/src/main/java/quarkus/extensions/combinator/maven/MavenGetQuarkusExtensions.java
+++ b/src/main/java/quarkus/extensions/combinator/maven/MavenGetQuarkusExtensions.java
@@ -1,21 +1,41 @@
 package quarkus.extensions.combinator.maven;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Logger;
 
 import quarkus.extensions.combinator.Configuration;
 import quarkus.extensions.combinator.utils.CommandBuilder;
 
 public class MavenGetQuarkusExtensions extends MavenCommand {
 
+    private static final Logger LOG = Logger.getLogger(MavenGetQuarkusExtensions.class.getName());
     private final List<String> extensions = new ArrayList<>();
 
     public List<String> getExtensions() {
         extensions.clear();
         String quarkusMavenPlugin = getQuarkusMavenPlugin();
-        runMavenCommandAndWait("-f", "target/test-classes/list-extensions.pom.xml", quarkusMavenPlugin + ":list-extensions",
-                "-Dformat=id");
+        withRetry(() -> runMavenCommandAndWait("-f", "target/test-classes/list-extensions.pom.xml",
+                quarkusMavenPlugin + ":list-extensions", "-Dformat=id"), 3);
         return extensions;
+    }
+
+    private void withRetry(Runnable cmd, int retryCount) {
+        int i = 1;
+        while (retryCount >= i++) {
+            try {
+                cmd.run();
+            } catch (RuntimeException e) {
+                LOG.severe("Output of failed Maven command: " + Arrays.toString(extensions.toArray()));
+                if (retryCount < i) {
+                    throw e;
+                }
+                extensions.clear();
+                continue;
+            }
+            break;
+        }
     }
 
     private String getQuarkusMavenPlugin() {


### PR DESCRIPTION
Extension combinations are flaky in Jenkins. I can't reproduce it. Maybe it is due to network blips (hence retry), but I'd also like to see output of failed command if there is any. An exception with failed command is already logged and it doesn't provide information needed to understand why is command failing.