### PR TITLE
Setup quarkus version in 3.8 branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>3.6.4</quarkus.version>
+        <quarkus.version>3.7.1</quarkus.version>
         <awaitility.version>4.2.0</awaitility.version>
         <rest-assured.version>5.4.0</rest-assured.version>
         <surefire-plugin.version>3.2.5</surefire-plugin.version>


### PR DESCRIPTION
I've manually created the 3.8 branch. Setting up quarkus version in it. 

For now it is set to quarkus 3.7.x, before actual 3.8.x is released