### PR TITLE
[3.8] Use a separate version for IDE config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>3.8.0</quarkus.version>
+        <quarkus.version>3.8.2</quarkus.version>
+        <quarkus.ide-config.version>3.8.2</quarkus.ide-config.version>
         <awaitility.version>4.2.0</awaitility.version>
         <rest-assured.version>5.4.0</rest-assured.version>
         <surefire-plugin.version>3.2.5</surefire-plugin.version>
@@ -106,7 +107,7 @@
                     <dependency>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-ide-config</artifactId>
-                        <version>${quarkus.version}</version>
+                        <version>${quarkus.ide-config.version}</version>
                     </dependency>
                 </dependencies>
                 <configuration>


### PR DESCRIPTION
Quarkus IDE config is not productised, so it should always use upstream version
Also, update Quarkus version to 3.8.2
Partial revert of https://github.com/quarkus-qe/quarkus-extensions-combinations/pull/234