### PR TITLE
Update Quarkus to 3.10.0, and mandrel to latest version

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -42,7 +42,8 @@ jobs:
     strategy:
       matrix:
         java: [ 17 ]
-        graalvm-version: ["mandrel-23.0.1.2-Final"]
+        graalvm-version: [ "mandrel-latest" ]
+        graalvm-java-version: [ "21" ]
     steps:
       - uses: actions/checkout@v3
       - name: Install JDK ${{ matrix.java }}
@@ -57,8 +58,7 @@ jobs:
         uses: graalvm/setup-graalvm@v1
         with:
           version: ${{ matrix.graalvm-version }}
-          java-version: ${{ matrix.java }}
-          components: 'native-image'
+          java-version: ${{ matrix.graalvm-java-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Test Suite
         run: mvn -ntp -e -s .github/mvn-settings.xml clean test -DquarkusRegistryClient=false -Dts.limit-extensions=20 -Dts.extensions-in-groups-of=5 -Dts.verify-native-mode=true -Ddisable-parallel

--- a/.github/workflows/weekly-with-registry.yml
+++ b/.github/workflows/weekly-with-registry.yml
@@ -41,7 +41,8 @@ jobs:
     strategy:
       matrix:
         java: [ 17 ]
-        graalvm-version: ["mandrel-23.0.1.2-Final"]
+        graalvm-version: [ "mandrel-latest" ]
+        graalvm-java-version: [ "21" ]
     steps:
       - uses: actions/checkout@v3
       - name: Install JDK ${{ matrix.java }}
@@ -56,8 +57,7 @@ jobs:
         uses: graalvm/setup-graalvm@v1
         with:
           version: ${{ matrix.graalvm-version }}
-          java-version: ${{ matrix.java }}
-          components: 'native-image'
+          java-version: ${{ matrix.graalvm-java-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Test Suite
         run: mvn -ntp -e -s .github/mvn-settings.xml clean test -Dts.limit-extensions=20 -Dts.extensions-in-groups-of=4 -Dts.verify-native-mode=true -Ddisable-parallel

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>3.9.3</quarkus.version>
-        <quarkus.ide-config.version>3.9.3</quarkus.ide-config.version>
+        <quarkus.version>3.10.0</quarkus.version>
+        <quarkus.ide-config.version>3.10.0</quarkus.ide-config.version>
         <awaitility.version>4.2.1</awaitility.version>
         <rest-assured.version>5.4.0</rest-assured.version>
         <surefire-plugin.version>3.2.5</surefire-plugin.version>


### PR DESCRIPTION
Quarkus 3.10.0 platform is released, let see how CI looking.

Updating mandrel as it have old version, We using same version in [testsuite](https://github.com/quarkus-qe/quarkus-test-suite/blob/main/.github/workflows/daily.yaml#L191)

Also removing native-image component as it's no longer needed, https://github.com/quarkus-qe/quarkus-extensions-combinations/actions/runs/9053974708