### PR TITLE
Quarkus bump and enable some extensions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>3.10.0</quarkus.version>
-        <quarkus.ide-config.version>3.10.0</quarkus.ide-config.version>
+        <quarkus.version>3.11.0</quarkus.version>
+        <quarkus.ide-config.version>3.11.0</quarkus.ide-config.version>
         <awaitility.version>4.2.1</awaitility.version>
         <rest-assured.version>5.4.0</rest-assured.version>
         <surefire-plugin.version>3.2.5</surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <guava.version>33.2.0-jre</guava.version>
         <jackson-databind.version>2.17.0</jackson-databind.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -177,6 +177,7 @@ messaging-amqp=skip-only-tests-on-windows
 # https://github.com/quarkusio/quarkus/issues/23383
 messaging-amqp,messaging-kafka=skip-all
 messaging-kafka=skip-only-tests-on-windows
+kafka-client=skip-only-tests-on-windows
 ## RESTEasy Qute with extensions using RESTEasy Reactive:
 resteasy-qute,rest-client-jackson=skip-all
 resteasy-qute,rest-client-jsonb=skip-all

--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -20,8 +20,6 @@ jdbc-mssql=skip-only-tests-on-windows
 jdbc-mysql=skip-only-tests-on-windows
 jdbc-postgresql=skip-only-tests-on-windows
 jooq=skip-all
-# https://github.com/quarkusio/quarkus/issues/32968, regression: https://github.com/quarkusio/quarkus/issues/33623
-kafka-client=skip-all
 # It needs keycloak
 keycloak-authorization=skip-tests
 # There is a name collision between io.quarkus:quarkus-logging-json and io.quarkiverse.loggingjson:quarkus-logging-json
@@ -209,6 +207,3 @@ kind=skip-all
 oidc-db-token-state-manager=skip-all
 # Conflict between amazon-lambda from io.quarkus and io.quarkiverse.amazonservices https://issues.redhat.com/browse/QUARKUS-4067
 amazon-lambda=skip-all
-# Rest qute on windows failing to build https://github.com/quarkusio/quarkus/issues/40055
-resteasy-qute=skip-native
-rest-qute=skip-native


### PR DESCRIPTION
Bumping Quarkus to the 3.11 as it was released. Also updating `maven.compiler` properties from 11 to 17 as we support only java 17+.

Disable kafka-client on windows as it's need docker.

Last removing some disabled extension as the issues seems be fixed or the issues claim to be fixed.