### PR TITLE
Bump Quarkus to 3.8.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>3.8.5</quarkus.version>
-        <quarkus.ide-config.version>3.8.5</quarkus.ide-config.version>
+        <quarkus.version>3.8.6</quarkus.version>
+        <quarkus.ide-config.version>3.8.6</quarkus.ide-config.version>
         <awaitility.version>4.2.0</awaitility.version>
         <rest-assured.version>5.4.0</rest-assured.version>
         <surefire-plugin.version>3.2.5</surefire-plugin.version>


### PR DESCRIPTION
Quarkus 3.8.6 is out so let's see if there are some errors in CI