### PR TITLE
[3.2] Reduce log size in CI runs by suppressing download transfer progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,6 @@ jobs:
           check-latest: true
           cache: 'maven'
       - name: Build with Maven
-        run: mvn -s .github/mvn-settings.xml clean test -Dts.limit-extensions=1
+        run: mvn -ntp -s .github/mvn-settings.xml clean test -Dts.limit-extensions=1
       - name: Verify extension that needs special properties
-        run: mvn -s .github/mvn-settings.xml clean test -Dts.includes-combinations-only-with-extensions=oidc -Dts.limit-extensions=1
+        run: mvn -ntp -s .github/mvn-settings.xml clean test -Dts.includes-combinations-only-with-extensions=oidc -Dts.limit-extensions=1


### PR DESCRIPTION
Reduces log heaviness. Adds `--no-transfer-progress` for maven execution to reduce "Downloading ...." messages

I didn't add option to daily job because simply we don't run daily workflows in branches