### PR TITLE
Bump Quarkus to  3.14.2 and fix daily

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         java: [ 17 ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -30,7 +30,7 @@ jobs:
           zip -r artifacts-linux-jvm${{ matrix.java }}.zip . -i '**/*-reports/*.xml' '**/*.log'
       - name: Archive artifacts
         if: failure()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ci-artifacts
           path: artifacts-linux-jvm${{ matrix.java }}.zip
@@ -45,9 +45,9 @@ jobs:
         graalvm-version: [ "mandrel-latest" ]
         graalvm-java-version: [ "21" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -68,7 +68,7 @@ jobs:
           zip -r artifacts-linux-native${{ matrix.java }}.zip . -i '**/*-reports/*.xml' '**/*.log'
       - name: Archive artifacts
         if: failure()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ci-artifacts
           path: artifacts-linux-native${{ matrix.java }}.zip
@@ -81,9 +81,9 @@ jobs:
       matrix:
         java: [ 17 ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -99,7 +99,7 @@ jobs:
           # Disambiguate windows find from cygwin find
           /usr/bin/find . -print | grep -e "-reports" -e ".log" | grep -v "git" | tar -czf artifacts-windows-jvm${{ matrix.java }}.tar -T -
       - name: Archive artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ci-artifacts
@@ -114,9 +114,9 @@ jobs:
         java: [ 17 ]
         graalvm-version: ["mandrel-23.0.1.2-Final"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -136,7 +136,7 @@ jobs:
       - name: Configure Pagefile
         # Increased the page-file size due to memory-consumption of native-image command
         # For details see https://github.com/actions/virtual-environments/issues/785
-        uses: al-cheb/configure-pagefile-action@v1.3
+        uses: al-cheb/configure-pagefile-action@v1.4
       - name: Run Test Suite
         shell: cmd
         # Windows have path limits and thus ts.extensions-in-groups-of is set to 1, generated app name is based on the extensions names
@@ -151,7 +151,7 @@ jobs:
           # Disambiguate windows find from cygwin find
           /usr/bin/find . -print | grep -e "-reports" -e ".log" | grep -v "git" | tar -czf artifacts-windows-native${{ matrix.java }}.tar -T -
       - name: Archive artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ci-artifacts

--- a/.github/workflows/weekly-with-registry.yml
+++ b/.github/workflows/weekly-with-registry.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         java: [ 17 ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -29,7 +29,7 @@ jobs:
           zip -r artifacts-linux-jvm${{ matrix.java }}.zip . -i '**/*-reports/*.xml' '**/*.log'
       - name: Archive artifacts
         if: failure()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ci-artifacts
           path: artifacts-linux-jvm${{ matrix.java }}.zip
@@ -44,9 +44,9 @@ jobs:
         graalvm-version: [ "mandrel-latest" ]
         graalvm-java-version: [ "21" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -67,7 +67,7 @@ jobs:
           zip -r artifacts-linux-native${{ matrix.java }}.zip . -i '**/*-reports/*.xml' '**/*.log'
       - name: Archive artifacts
         if: failure()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ci-artifacts
           path: artifacts-linux-native${{ matrix.java }}.zip

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>3.14.1</quarkus.version>
+        <quarkus.version>3.14.2</quarkus.version>
         <quarkus.ide-config.version>3.14.1</quarkus.ide-config.version>
         <awaitility.version>4.2.1</awaitility.version>
         <rest-assured.version>5.5.0</rest-assured.version>


### PR DESCRIPTION
Bumping Quarkus to 3.14.2 as it's available.
Bumping various CI action as some of them were deprecated in that version and causing the daily build fail.