### PR TITLE
Bump Quarkus to 3.16.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>3.15.1</quarkus.version>
-        <quarkus.ide-config.version>3.15.1</quarkus.ide-config.version>
+        <quarkus.version>3.16.1</quarkus.version>
+        <quarkus.ide-config.version>3.16.1</quarkus.ide-config.version>
         <awaitility.version>4.2.1</awaitility.version>
         <rest-assured.version>5.5.0</rest-assured.version>
         <surefire-plugin.version>3.5.2</surefire-plugin.version>

--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -35,6 +35,7 @@ mybatis=skip-all
 # https://github.com/quarkusio/quarkus/issues/28809
 narayana-lra=skip-all
 oidc=skip-only-tests-on-windows
+oidc-client=skip-only-tests-on-windows
 reactive-mysql-client=skip-only-tests-on-windows
 # camel-quarkus-fhir exceeds the -Dquarkus.native.native-image-xmx=4g limit
 camel-quarkus-fhir=skip-native


### PR DESCRIPTION
Bumping Quarkus to latest version 3.16.1. Let's see what CI think about it.