### PR TITLE
Exclusions for oidc client related extensions for Windows

### DIFF
--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -34,8 +34,14 @@ micrometer-registry-stackdriver=skip-tests
 mybatis=skip-all
 # https://github.com/quarkusio/quarkus/issues/28809
 narayana-lra=skip-all
+# No containers on Windows GH Action runners
 oidc=skip-only-tests-on-windows
 oidc-client=skip-only-tests-on-windows
+oidc-client-graphql=skip-only-tests-on-windows
+rest-client-oidc-filter=skip-only-tests-on-windows
+resteasy-client-oidc-filter=skip-only-tests-on-windows
+rest-client-oidc-token-propagation=skip-only-tests-on-windows
+resteasy-client-oidc-token-propagation=skip-only-tests-on-windows
 reactive-mysql-client=skip-only-tests-on-windows
 # camel-quarkus-fhir exceeds the -Dquarkus.native.native-image-xmx=4g limit
 camel-quarkus-fhir=skip-native


### PR DESCRIPTION
Exclusions for oidc client related extensions for Windows

Triggered by https://github.com/quarkusio/quarkus/pull/43609 change
Expanding https://github.com/quarkus-qe/quarkus-extensions-combinations/commit/c4883c3bdb596108ecc9d2681115843b0240d6d2 change