### PR TITLE
Bump Quarkus to 3.17.3 and fix daily

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>3.17.2</quarkus.version>
-        <quarkus.ide-config.version>3.17.2</quarkus.ide-config.version>
+        <quarkus.version>3.17.3</quarkus.version>
+        <quarkus.ide-config.version>3.17.3</quarkus.ide-config.version>
         <awaitility.version>4.2.1</awaitility.version>
         <rest-assured.version>5.5.0</rest-assured.version>
         <surefire-plugin.version>3.5.2</surefire-plugin.version>

--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -215,3 +215,4 @@ kind=skip-all
 oidc-db-token-state-manager=skip-all
 # Conflict between amazon-lambda from io.quarkus and io.quarkiverse.amazonservices https://issues.redhat.com/browse/QUARKUS-4067
 amazon-lambda=skip-all
+elasticsearch-rest-client=skip-only-tests-on-windows


### PR DESCRIPTION
Bump Quarkus to 3.17.3 and fixing daily by disable test for `elasticsearch-rest-client` extension. Tested it localy and it starting the devservice. The devservice was present also in 3.8 so it seems weird why it start failing not. 

Only think what I can think of is that it wasn't present in registry or something like this.