### PR TITLE
Bump Quarkus to 3.18.1 and update mandrel version for Windows runners

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -112,7 +112,8 @@ jobs:
     strategy:
       matrix:
         java: [ 17 ]
-        graalvm-version: ["mandrel-23.0.1.2-Final"]
+        graalvm-version: [ "mandrel-latest" ]
+        graalvm-java-version: [ "21" ]
     steps:
       - uses: actions/checkout@v4
       - name: Install JDK ${{ matrix.java }}
@@ -130,8 +131,7 @@ jobs:
         uses: graalvm/setup-graalvm@v1
         with:
           version: ${{ matrix.graalvm-version }}
-          java-version: ${{ matrix.java }}
-          components: 'native-image'
+          java-version: ${{ matrix.graalvm-java-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure Pagefile
         # Increased the page-file size due to memory-consumption of native-image command

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>3.17.6</quarkus.version>
-        <quarkus.ide-config.version>3.17.6</quarkus.ide-config.version>
+        <quarkus.version>3.18.1</quarkus.version>
+        <quarkus.ide-config.version>3.18.1</quarkus.ide-config.version>
         <awaitility.version>4.2.1</awaitility.version>
         <rest-assured.version>5.5.0</rest-assured.version>
         <surefire-plugin.version>3.5.2</surefire-plugin.version>


### PR DESCRIPTION
Bumping Quarkus to 3.18.1 as platform was released