### PR TITLE
Bump Quarkus to 3.19.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>3.18.1</quarkus.version>
-        <quarkus.ide-config.version>3.18.1</quarkus.ide-config.version>
+        <quarkus.version>3.19.1</quarkus.version>
+        <quarkus.ide-config.version>3.19.1</quarkus.ide-config.version>
         <awaitility.version>4.3.0</awaitility.version>
         <rest-assured.version>5.5.1</rest-assured.version>
         <surefire-plugin.version>3.5.2</surefire-plugin.version>


### PR DESCRIPTION
Bump Quarkus to 3.19.1. Let's see how CI looks like as this is base for LTS