### PR TITLE
[3.15] Bump Quarkus to 3.15.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>3.15.5</quarkus.version>
-        <quarkus.ide-config.version>3.15.5</quarkus.ide-config.version>
+        <quarkus.version>3.15.6</quarkus.version>
+        <quarkus.ide-config.version>3.15.6</quarkus.ide-config.version>
         <awaitility.version>4.2.1</awaitility.version>
         <rest-assured.version>5.5.0</rest-assured.version>
         <surefire-plugin.version>3.5.0</surefire-plugin.version>


### PR DESCRIPTION
Use the latest released 3.15-based Quarkus