### PR TITLE
Change the tag for supported product extension

### DIFF
--- a/src/test/java/quarkus/extensions/combinator/extensions/CheckSuppertedQuarkusExtension.java
+++ b/src/test/java/quarkus/extensions/combinator/extensions/CheckSuppertedQuarkusExtension.java
@@ -9,7 +9,7 @@ import quarkus.extensions.combinator.Configuration;
 
 public final class CheckSuppertedQuarkusExtension {
 
-    private static final String SUPPORTED_TAG = "redhat-support:supported";
+    private static final String SUPPORTED_TAG = "support:full-support";
 
     private static final CheckSuppertedQuarkusExtension INSTANCE = new CheckSuppertedQuarkusExtension();
 


### PR DESCRIPTION
The supported tag was changed few days ago, when adding the support to ibm and u[dating the code.quarkus.

To do it more universal, the `<support-scope>:<support-level>` (`redhat-support:tech-preview`) was transformed to `support:<support-level>` (`support:tech-preview`).

Only one which changing the support level name is `supported` level. It's transformed to `full-support`. This can be found in https://github.com/redhat-developer/code.quarkus.redhat.com/blob/main/src/main/java/OfferingPlatformOverride.java#L76

The all tags can be found in https://github.com/redhat-developer/code.quarkus.redhat.com/blob/main/src/main/resources/web/redhat-app/index.jsx#L12

Also this will need backported. I'll do it for all supported streams after this is merged 