### PR TITLE
[3.27] Exclude funqy-amazon-lambda due to QUARKUS-6563

### DIFF
--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -216,3 +216,5 @@ oidc-db-token-state-manager=skip-all
 # Conflict between amazon-lambda from io.quarkus and io.quarkiverse.amazonservices https://issues.redhat.com/browse/QUARKUS-4067
 amazon-lambda=skip-all
 elasticsearch-rest-client=skip-only-tests-on-windows
+# Disabled due to https://issues.redhat.com/browse/QUARKUS-6563
+funqy-amazon-lambda=skip-tests


### PR DESCRIPTION
* The codestart is broken. See https://issues.redhat.com/browse/QUARKUS-6563