### PR TITLE
Exclude funqy-amazon-lambda due to quarkus#50402

### DIFF
--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -216,3 +216,5 @@ oidc-db-token-state-manager=skip-all
 # Conflict between amazon-lambda from io.quarkus and io.quarkiverse.amazonservices https://issues.redhat.com/browse/QUARKUS-4067
 amazon-lambda=skip-all
 elasticsearch-rest-client=skip-only-tests-on-windows
+# Disabled due to https://github.com/quarkusio/quarkus/issues/50402
+funqy-amazon-lambda=skip-tests


### PR DESCRIPTION
* The property for testing with random mock server endpoint port is broken, see https://github.com/quarkusio/quarkus/issues/50402