### PR TITLE
Increase xmx for native to 6g, enable camel-quarkus-fhir

### DIFF
--- a/src/main/java/quarkus/extensions/combinator/maven/MavenProject.java
+++ b/src/main/java/quarkus/extensions/combinator/maven/MavenProject.java
@@ -21,7 +21,7 @@ public class MavenProject extends MavenCommand {
     private static final String RANDOM_PORT_FOR_TESTS = "-Dquarkus.http.test-port=0";
     private static final String RANDOM_PORT_FOR_TESTS_LAMBDA = "-Dquarkus.lambda.mock-event-server.test-port=0";
     private static final String RANDOM_PORT_FOR_RUNNING = "-Dquarkus.http.port=0";
-    private static final String XMX_MEMORY_LIMIT = "-Dquarkus.native.native-image-xmx=4g";
+    private static final String XMX_MEMORY_LIMIT = "-Dquarkus.native.native-image-xmx=6g";
 
     private final File output;
     private final Set<String> projectExtensions;

--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -43,8 +43,6 @@ resteasy-client-oidc-filter=skip-only-tests-on-windows
 rest-client-oidc-token-propagation=skip-only-tests-on-windows
 resteasy-client-oidc-token-propagation=skip-only-tests-on-windows
 reactive-mysql-client=skip-only-tests-on-windows
-# camel-quarkus-fhir exceeds the -Dquarkus.native.native-image-xmx=4g limit
-camel-quarkus-fhir=skip-native
 # Extensions that use testscontainers are currently not supported by Windows
 reactive-pg-client=skip-only-tests-on-windows
 kubernetes-config=skip-only-tests-on-windows


### PR DESCRIPTION
Increase xmx for native to 6g, enable camel-quarkus-fhir

Trigger: investigation of https://github.com/quarkus-qe/quarkus-extensions-combinations/actions/runs/19443530228

Similar bum was done in QE TS, see https://github.com/quarkus-qe/quarkus-test-suite/pull/2756 for details