### PR TITLE
Bump quarkus 3.30.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>3.29.0</quarkus.version>
-        <quarkus.ide-config.version>3.29.0</quarkus.ide-config.version>
+        <quarkus.version>3.30.2</quarkus.version>
+        <quarkus.ide-config.version>3.30.2</quarkus.ide-config.version>
         <awaitility.version>4.3.0</awaitility.version>
         <rest-assured.version>5.5.6</rest-assured.version>
         <surefire-plugin.version>3.5.4</surefire-plugin.version>

--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -217,4 +217,4 @@ elasticsearch-rest-client=skip-only-tests-on-windows
 # Disabled due to https://github.com/quarkusio/quarkus/issues/50402
 funqy-amazon-lambda=skip-tests
 # Remove when https://github.com/quarkusio/quarkus/issues/50793 is fixed + test it with manually with hibernate-orm
-spring-data-jpa=skip-all
+spring-data-jpa=skip-tests


### PR DESCRIPTION
Bump Quarkus to 3.30.2

Change spring-data-jpa from skip to skip tests as the issue is fixed for build time but the tests and dev mode still have problem.