### PR TITLE
Include Java 21 runs to weekly and native PR CI jobs

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -41,7 +41,7 @@ jobs:
       TESTCONTAINERS_RYUK_DISABLED: true
     strategy:
       matrix:
-        java: [ 17 ]
+        java: [ 21 ]
         graalvm-version: [ "mandrel-latest" ]
         graalvm-java-version: [ "21" ]
     steps:
@@ -111,7 +111,7 @@ jobs:
       TESTCONTAINERS_RYUK_DISABLED: true
     strategy:
       matrix:
-        java: [ 17 ]
+        java: [ 21 ]
         graalvm-version: [ "mandrel-latest" ]
         graalvm-java-version: [ "21" ]
     steps:

--- a/.github/workflows/weekly-with-registry.yml
+++ b/.github/workflows/weekly-with-registry.yml
@@ -11,7 +11,7 @@ jobs:
       TESTCONTAINERS_RYUK_DISABLED: true
     strategy:
       matrix:
-        java: [ 17 ]
+        java: [ 17, 21 ]
     steps:
       - uses: actions/checkout@v4
       - name: Install JDK ${{ matrix.java }}
@@ -40,7 +40,7 @@ jobs:
       TESTCONTAINERS_RYUK_DISABLED: true
     strategy:
       matrix:
-        java: [ 17 ]
+        java: [ 21 ]
         graalvm-version: [ "mandrel-latest" ]
         graalvm-java-version: [ "21" ]
     steps:


### PR DESCRIPTION
- Run weekly job with Java 17 and 21
- Updates all native jobs to run with Java 21 as they already use java21-based native image