### PR TITLE
Bump to 3.20.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>3.20.5</quarkus.version>
-        <quarkus.ide-config.version>3.20.5</quarkus.ide-config.version>
+        <quarkus.version>3.20.6</quarkus.version>
+        <quarkus.ide-config.version>3.20.6</quarkus.ide-config.version>
         <awaitility.version>4.3.0</awaitility.version>
         <rest-assured.version>5.5.1</rest-assured.version>
         <surefire-plugin.version>3.5.2</surefire-plugin.version>


### PR DESCRIPTION
Bump to 3.20.6

`<quarkus.version>3.20.6</quarkus.version>
        <quarkus.ide-config.version>3.20.6</quarkus.ide-config.version>`