### PR TITLE
Fix CI artifact upload conflicts

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,7 +30,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ci-artifacts
+          name: ci-artifacts-linux-jvm${{ matrix.java }}
           path: artifacts-linux-jvm${{ matrix.java }}.zip
   linux-build-released-native:
     name: Linux - Native build - released Quarkus
@@ -68,7 +68,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ci-artifacts
+          name: ci-artifacts-linux-native${{ matrix.java }}
           path: artifacts-linux-native${{ matrix.java }}.zip
   windows-build-released-jvm:
     name: Windows - JVM build - released Quarkus
@@ -100,7 +100,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: ci-artifacts
+          name: ci-artifacts-windows-jvm${{ matrix.java }}
           path: artifacts-windows-jvm${{ matrix.java }}.tar
   windows-build-released-native:
     name: Windows - Native build - released Quarkus
@@ -152,5 +152,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: ci-artifacts
+          name: ci-artifacts-windows-native${{ matrix.java }}
           path: artifacts-windows-native${{ matrix.java }}.tar

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -31,7 +31,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ci-artifacts
+          name: ci-artifacts-linux-jvm${{ matrix.java }}
           path: artifacts-linux-jvm${{ matrix.java }}.zip
   linux-build-released-native:
     name: Linux - Native build - released Quarkus
@@ -69,7 +69,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ci-artifacts
+          name: ci-artifacts-linux-native${{ matrix.java }}
           path: artifacts-linux-native${{ matrix.java }}.zip
   windows-build-released-jvm:
     name: Windows - JVM build - released Quarkus
@@ -101,7 +101,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: ci-artifacts
+          name: ci-artifacts-windows-jvm${{ matrix.java }}
           path: artifacts-windows-jvm${{ matrix.java }}.tar
   windows-build-released-native:
     name: Windows - Native build - released Quarkus
@@ -153,5 +153,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: ci-artifacts
+          name: ci-artifacts-windows-native${{ matrix.java }}
           path: artifacts-windows-native${{ matrix.java }}.tar


### PR DESCRIPTION
To fix this error:
`
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
0s
`
https://github.com/quarkus-qe/quarkus-extensions-combinations/actions/runs/23659721505/job/68926469116?pr=437

As we did the same in others repo such as: https://github.com/quarkus-qe/quarkus-startstop/pull/669