### PR TITLE
Add removal of `@Entity` for hibernate-panache-next

### DIFF
--- a/src/main/java/quarkus/extensions/combinator/maven/MavenGenerator.java
+++ b/src/main/java/quarkus/extensions/combinator/maven/MavenGenerator.java
@@ -29,6 +29,7 @@ public class MavenGenerator extends MavenCommand {
     private static final String APPLICATION_PROPERTIES = RESOURCES_FOLDER + "/application" + PROPERTIES_FORMAT;
     private static final String OUTPUT_FOLDER = "target/";
     private static final String HIBERNATE_ORM_EXTENSION = "hibernate-orm";
+    private static final String HIBERNATE_PANACHE_EXTENSION = "hibernate-panache";
 
     private static final String EXTENSIONS_PARAM = "extensions";
 
@@ -99,7 +100,7 @@ public class MavenGenerator extends MavenCommand {
     }
 
     public void dropEntityAnnotations() {
-        if (withExtensions().contains(HIBERNATE_ORM_EXTENSION)) {
+        if (withExtensions().contains(HIBERNATE_ORM_EXTENSION) || withExtensions().contains(HIBERNATE_PANACHE_EXTENSION)) {
             File srcMainJava = new File(projectAsWorkingDirectory(), JAVA_FOLDER);
             try {
                 Files.walk(srcMainJava.toPath())


### PR DESCRIPTION
The `hibernate-panache-next` is new extension and it have similar code start as hibernate-orm-*. For hibernate-orm we strip the `@Entity` annotation so the build don't fail, the same is needed for `hibernate-panache-next`