### PR TITLE
Bump Quarkus and small update

### DIFF
--- a/.github/actions/use-docker-mirror/action.yml
+++ b/.github/actions/use-docker-mirror/action.yml
@@ -1,0 +1,20 @@
+name: 'Use Google and AWS Docker mirrors'
+description: 'We hit Docker pull rate limits in past and using mirrors helps'
+runs:
+  using: "composite"
+  steps:
+    - name: Configure Docker mirror
+      shell: bash
+      run: |
+        cat << EOF > ./daemon.json
+        {
+          "registry-mirrors": ["https://mirror.gcr.io", "https://public.ecr.aws/docker"]
+        }
+        EOF
+        sudo bash -c 'cp ./daemon.json /etc/docker/daemon.json'
+        sudo bash -c 'systemctl restart docker'
+        # exit if mirror hasn't been configured
+        docker info > docker-info
+        # print Docker info so that we can visually check it
+        cat docker-info
+        (cat docker-info | grep -q 'mirror.gcr.io') && (cat docker-info | grep -q 'public.ecr.aws') || exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,6 +20,7 @@ jobs:
           java-version: ${{ matrix.java }}
           check-latest: true
           cache: 'maven'
+      - uses: ./.github/actions/use-docker-mirror
       - name: Run Test Suite
         run: mvn -ntp -s .github/mvn-settings.xml clean test -DquarkusRegistryClient=false -Dts.limit-extensions=200 -Dts.extensions-in-groups-of=2
       - name: Zip Artifacts
@@ -58,6 +59,7 @@ jobs:
           version: ${{ matrix.graalvm-version }}
           java-version: ${{ matrix.graalvm-java-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/use-docker-mirror
       - name: Run Test Suite
         run: mvn -ntp -e -s .github/mvn-settings.xml clean test -DquarkusRegistryClient=false -Dts.limit-extensions=20 -Dts.extensions-in-groups-of=5 -Dts.verify-native-mode=true -Ddisable-parallel
       - name: Zip Artifacts

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -21,6 +21,7 @@ jobs:
           java-version: ${{ matrix.java }}
           check-latest: true
           cache: 'maven'
+      - uses: ./.github/actions/use-docker-mirror
       - name: Run Test Suite
         run: mvn -ntp -s .github/mvn-settings.xml clean test -Dts.limit-extensions=300 -Dts.extensions-in-groups-of=2
       - name: Zip Artifacts
@@ -59,6 +60,7 @@ jobs:
           version: ${{ matrix.graalvm-version }}
           java-version: ${{ matrix.graalvm-java-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/use-docker-mirror
       - name: Run Test Suite
         run: mvn -ntp -e -s .github/mvn-settings.xml clean test -Dts.limit-extensions=40 -Dts.extensions-in-groups-of=4 -Dts.verify-native-mode=true -Ddisable-parallel
       - name: Zip Artifacts

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>3.35.2</quarkus.version>
-        <quarkus.ide-config.version>3.35.2</quarkus.ide-config.version>
+        <quarkus.version>3.37.1</quarkus.version>
+        <quarkus.ide-config.version>3.37.1</quarkus.ide-config.version>
         <awaitility.version>4.3.0</awaitility.version>
         <rest-assured.version>6.0.0</rest-assured.version>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>

--- a/src/main/resources/exclusions.properties
+++ b/src/main/resources/exclusions.properties
@@ -214,5 +214,3 @@ oidc-db-token-state-manager=skip-all
 # Conflict between amazon-lambda from io.quarkus and io.quarkiverse.amazonservices https://issues.redhat.com/browse/QUARKUS-4067
 amazon-lambda=skip-all
 elasticsearch-rest-client=skip-only-tests-on-windows
-# Disabled due to https://github.com/quarkusio/quarkus/issues/50402
-funqy-amazon-lambda=skip-tests


### PR DESCRIPTION
Bumping Quarkus to 3.37.0, enabling `funqy-amazon-lambda` as it seems to be fixed and adding the docker proxy for images. Few weeks back I saw that the we have problems with limits, this should do same what we doing in TS to prevent it from happening