### PR TITLE
Bump Quarkus to 3.38.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>3.37.2</quarkus.version>
-        <quarkus.ide-config.version>3.37.2</quarkus.ide-config.version>
+        <quarkus.version>3.38.0</quarkus.version>
+        <quarkus.ide-config.version>3.38.0</quarkus.ide-config.version>
         <awaitility.version>4.3.0</awaitility.version>
         <rest-assured.version>6.0.1</rest-assured.version>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>

--- a/src/main/resources/jdbc-mssql/container-license-acceptance.txt
+++ b/src/main/resources/jdbc-mssql/container-license-acceptance.txt
@@ -1,3 +1,4 @@
 mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-latest
 mcr.microsoft.com/mssql/server:2022-latest
+mcr.microsoft.com/mssql/server:2025-latest

--- a/src/main/resources/reactive-mssql-client/container-license-acceptance.txt
+++ b/src/main/resources/reactive-mssql-client/container-license-acceptance.txt
@@ -1,3 +1,4 @@
 mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-latest
 mcr.microsoft.com/mssql/server:2022-latest
+mcr.microsoft.com/mssql/server:2025-latest


### PR DESCRIPTION
Bump Quarkus to 3.38.0

Add MSSql 2025 to accepted license list. This was added in https://github.com/quarkusio/quarkus/pull/55219