### PR TITLE
Bump Quarkus to 3.38.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>3.38.0</quarkus.version>
-        <quarkus.ide-config.version>3.38.0</quarkus.ide-config.version>
+        <quarkus.version>3.38.1</quarkus.version>
+        <quarkus.ide-config.version>3.38.1</quarkus.ide-config.version>
         <awaitility.version>4.3.0</awaitility.version>
         <rest-assured.version>6.0.1</rest-assured.version>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>


### PR DESCRIPTION
Bump Quarkus to 3.38.1

Fixes ClassNotFoundException on io.netty.internal.tcnative.SSL in native for certain cases - e.g. hibernate-search-orm-elasticsearch, infinispan-client, jdbc-mssql, narayana-jta

This is why the latest daily run failed

Upstream issue - https://github.com/quarkusio/quarkus/issues/55871